### PR TITLE
Fix issues identified by mypy.

### DIFF
--- a/src/base64io/__init__.py
+++ b/src/base64io/__init__.py
@@ -23,7 +23,7 @@ LOGGER_NAME = 'base64io'
 
 try:  # Python 3.5.0 and 3.5.1 have incompatible typing modules
     from types import TracebackType  # noqa pylint: disable=unused-import
-    from typing import IO, Iterable, List, Optional  # noqa pylint: disable=unused-import
+    from typing import IO, Iterable, List, Type, Optional  # noqa pylint: disable=unused-import
 except ImportError:  # pragma: no cover
     # We only actually need these imports when running the mypy checks
     pass
@@ -86,7 +86,7 @@ class Base64IO(io.IOBase):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        # type: (type, BaseException, TracebackType) -> None
+        # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> bool
         """Properly close self on exit."""
         self.close()
 

--- a/src/base64io/__init__.py
+++ b/src/base64io/__init__.py
@@ -89,6 +89,7 @@ class Base64IO(io.IOBase):
         # type: (Optional[Type[BaseException]], Optional[BaseException], Optional[TracebackType]) -> bool
         """Properly close self on exit."""
         self.close()
+        return False
 
     def close(self):
         # type: () -> None

--- a/src/base64io/__init__.py
+++ b/src/base64io/__init__.py
@@ -231,8 +231,8 @@ class Base64IO(io.IOBase):
             _remaining_bytes_to_read = total_bytes_to_read - _data_buffer.tell()
         return _data_buffer.getvalue()
 
-    def read(self, b=None):
-        # type: (Optional[int]) -> bytes
+    def read(self, b=-1):
+        # type: (int) -> bytes
         """Read bytes from wrapped stream, base64-decoding before return.
 
         .. note::
@@ -250,10 +250,12 @@ class Base64IO(io.IOBase):
         if not self.readable():
             raise IOError('Stream is not readable')
 
-        if b is not None and b < 0:
-            b = None
-        _bytes_to_read = None
-        if b is not None:
+        if b is None or b < 0:
+            b = -1
+            _bytes_to_read = -1
+        elif b == 0:
+            _bytes_to_read = 0
+        elif b > 0:
             # Calculate number of encoded bytes that must be read to get b raw bytes.
             _bytes_to_read = int((b - len(self.__read_buffer)) * 4 / 3)
             _bytes_to_read += (4 - _bytes_to_read % 4)

--- a/test/unit/test_base64_stream.py
+++ b/test/unit/test_base64_stream.py
@@ -133,7 +133,7 @@ def build_test_cases():
     test_cases = []
 
     # exact single-shot, varying multiples
-    for size in (1, 2, 3, 4, 5, 6, 7, 222, 1024):
+    for size in (0, 1, 2, 3, 4, 5, 6, 7, 222, 1024):
         test_cases.append((size, size, 1, size))
 
     test_cases.append((1024, None, 1, 1024))  # single-shot

--- a/test/unit/test_base64_stream.py
+++ b/test/unit/test_base64_stream.py
@@ -136,8 +136,9 @@ def build_test_cases():
     for size in (0, 1, 2, 3, 4, 5, 6, 7, 222, 1024):
         test_cases.append((size, size, 1, size))
 
-    test_cases.append((1024, None, 1, 1024))  # single-shot
-    test_cases.append((1024, -1, 1, 1024))  # single-shot
+    # general single-shot: not affected by size
+    for single_shot in (None, -1, -99):
+        test_cases.append((1024, single_shot, 1, 1024))
 
     # Odd multiples with operation smaller, equal to, and larger than total
     for rounds in (1, 3, 5):


### PR DESCRIPTION
*Description of changes:*
Some minor mypy annotation tweaks to correctly describe behavior.

In running through the mypy results, however, it identified that there were a couple subtle issues with two methods:
* `read()` should only accept an `int`, not `None`. I updated this to behave correctly but let it continue to accept `None` as input.
    * https://docs.python.org/2/library/io.html#io.RawIOBase.read
* `__exit__()` should explicitly `False` rather than just [falsey] `None`.
    * https://www.python.org/dev/peps/pep-0343/#specification-the-with-statement


CI run. Note: the py33 and py37 runs are broken in the Travis config. A fix for that is in #7 .

https://travis-ci.org/mattsb42-aws/base64io-python/builds/389402410

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
