### PR TITLE
CI/Black badges and version 1.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,13 @@
 Changelog
 *********
 
-1.0.0
-=====
+1.0.1 -- 2018-06-12
+===================
+
+* Fix minor compatibility issues with ``read()`` and ``__exit__()``
+  `#6 <https://github.com/awslabs/base64io-python/pull/6>`_
+
+1.0.0 -- 2018-05-16
+===================
 
 * Initial public release

--- a/README.rst
+++ b/README.rst
@@ -10,9 +10,19 @@ base64io
    :target: https://pypi.python.org/pypi/base64io
    :alt: Supported Python Versions
 
+.. image:: https://img.shields.io/badge/code_style-black-000000.svg
+   :target: https://github.com/ambv/black
+   :alt: Code style: black
+
 .. image:: https://readthedocs.org/projects/base64io-python/badge/
    :target: https://base64io-python.readthedocs.io/en/stable/
    :alt: Documentation Status
+
+.. image:: https://travis-ci.org/awslabs/base64io-python.svg?branch=master
+   :target: https://travis-ci.org/awslabs/base64io-python
+
+.. image:: https://ci.appveyor.com/api/projects/status/ds8xvogp4m70j9ks?svg=true
+   :target: https://ci.appveyor.com/project/mattsb42-aws/base64io-python-36722
 
 This project is designed to develop a class, :class:`base64io.Base64IO`, that implements
 a streaming interface for Base64 encoding.

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     version=get_version(),
     packages=find_packages("src"),
     package_dir={"": "src"},
-    url="http://base64io.readthedocs.io/en/latest/",
+    url="https://github.com/awslabs/base64io-python",
     author="Amazon Web Services",
     author_email="aws-cryptools@amazon.com",
     maintainer="Amazon Web Services",

--- a/src/base64io/__init__.py
+++ b/src/base64io/__init__.py
@@ -29,7 +29,7 @@ except ImportError:  # pragma: no cover
     pass
 
 __all__ = ("Base64IO",)
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 _LOGGER = logging.getLogger(LOGGER_NAME)
 
 


### PR DESCRIPTION
*Description of changes:*

* Version bump to 1.0.1 to publish #6.
* Add CI and Black badges to readme.
* Warehouse offers nice integrations with GitHub if that is what is set for the url in `setup.py`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
