### PR TITLE
fix hypothesis >= 3.36.0 functionality

### DIFF
--- a/test/functional/test_f_base64_stream.py
+++ b/test/functional/test_f_base64_stream.py
@@ -38,7 +38,6 @@ HYPOTHESIS_SETTINGS = hypothesis.settings(
 BINARY = hypothesis_strategies.binary()
 
 
-@pytest.mark.hypothesis
 @HYPOTHESIS_SETTINGS
 @hypothesis.given(source=BINARY)
 def test_cycle(source):


### PR DESCRIPTION
*Issue #, if available:* #14

*Description of changes:*
pin hypothesis dependency to 3.63.0

https://github.com/HypothesisWorks/hypothesis/issues/1362

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
